### PR TITLE
Allow passwords to be retrieved from a credentials file instead of only on the command line & support revoking tokens

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('LICENSE.txt') as f:
 
 setup(
     name='teslatoken',
-    version='0.1.3',
+    version='0.1.4',
     description='Tool to create authorization tokens for Tesla cars.',
     long_description=readme,
     license=license,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('LICENSE.txt') as f:
 
 setup(
     name='teslatoken',
-    version='0.1.4',
+    version='0.1.5',
     description='Tool to create authorization tokens for Tesla cars.',
     long_description=readme,
     license=license,

--- a/teslatoken.py
+++ b/teslatoken.py
@@ -25,6 +25,8 @@ def main():
     parser.add_argument("-r", "--refresh", metavar='REFRESH_TOKEN', default=None, help="Refresh token for an access token")
     parser.add_argument("-q", "--quiet", action='store_true', help="Do not print token to stdout")
     parser.add_argument('--version', action='version', version='%(prog)s 0.1')
+    parser.add_argument('--revoke', action='store_true', help="Revokes a previously acquired access token")
+    parser.add_argument('-a', '--access_token', metavar='ACCESS_TOKEN', help="The access token to be revoked")
 
     args = parser.parse_args()
 
@@ -40,6 +42,8 @@ def main():
 
     headers = {'client_id': client_data['OWNERAPI_CLIENT_ID']}
 
+    request_url = 'https://owner-api.teslamotors.com/oauth/token';
+    acquire_token = True
     if args.username and args.password:
         headers.update({'grant_type': 'password', 'email': args.username, 'password': args.password})
         headers.update({'client_secret': client_data['OWNERAPI_CLIENT_SECRET']})
@@ -50,28 +54,35 @@ def main():
         headers.update({'client_secret': client_data['OWNERAPI_CLIENT_SECRET']})
     elif args.refresh:
         headers.update({'grant_type': 'refresh_token', 'refresh_token': args.refresh})
+    elif args.revoke and args.access_token:
+        request_url = 'https://owner-api.teslamotors.com/oauth/revoke';
+        acquire_token = False
+        headers.update({'token': args.access_token})
     else:
         error('Either username/password or refresh token must be provided.')
 
     try:
-        request = Request('https://owner-api.teslamotors.com/oauth/token', data=urlencode(headers).encode('utf-8'))
+        request = Request(request_url, data=urlencode(headers).encode('utf-8'))
         response = json.loads(urlopen(request, cafile = certifi.where()).read())
     except HTTPError as err:
         error('An HTTP error occurred during authorization: %d: %s' % (err.code, err.msg))
     except URLError as err:
         error('An URL error occurred during authorization: %s' % err.reason)
 
-    if not args.quiet:
-        print('\n')
-        print(' Access Token: %s' % response['access_token'])
-        print('Refresh Token: %s' % response['refresh_token'])
-        print(' Requested at: %s' % readable_time(response['created_at']))
-        print('   Expires at: %s' % readable_time((response['created_at'] + response['expires_in'])))
+    if acquire_token:
+        if not args.quiet:
+            print('\n')
+            print(' Access Token: %s' % response['access_token'])
+            print('Refresh Token: %s' % response['refresh_token'])
+            print(' Requested at: %s' % readable_time(response['created_at']))
+            print('   Expires at: %s' % readable_time((response['created_at'] + response['expires_in'])))
 
-    if args.output:
-        with open(args.output, 'w') as outfile:
-            json.dump(response, outfile, sort_keys=True, indent=2)
-        print('\nAccess token written to %s' % args.output)
+        if args.output:
+            with open(args.output, 'w') as outfile:
+                json.dump(response, outfile, sort_keys=True, indent=2)
+            print('\nAccess token written to %s' % args.output)
+    else:
+        print('\nSuccessfully revoked')
 
 
 def readable_time(timestamp):

--- a/teslatoken.py
+++ b/teslatoken.py
@@ -21,6 +21,7 @@ def main():
     parser.add_argument("-o", "--output", metavar='FILE', default=None, help="Write to file FILE (json format)")
     parser.add_argument("-u", "--username", metavar='USER', default=None, help="Username for your MyTesla account")
     parser.add_argument("-p", "--password", metavar='PASS', default=None, help="Password for your MyTesla account")
+    parser.add_argument("-c", "--credential_file", metavar='CREDENTIAL_FILE', default=None, help="File which contains your MyTesla account password")
     parser.add_argument("-r", "--refresh", metavar='REFRESH_TOKEN', default=None, help="Refresh token for an access token")
     parser.add_argument("-q", "--quiet", action='store_true', help="Do not print token to stdout")
     parser.add_argument('--version', action='version', version='%(prog)s 0.1')
@@ -41,6 +42,11 @@ def main():
 
     if args.username and args.password:
         headers.update({'grant_type': 'password', 'email': args.username, 'password': args.password})
+        headers.update({'client_secret': client_data['OWNERAPI_CLIENT_SECRET']})
+    elif args.username and args.credential_file:
+        with open(args.credential_file) as f:
+            credentials = f.readline().strip()
+        headers.update({'grant_type': 'password', 'email': args.username, 'password': credentials})
         headers.update({'client_secret': client_data['OWNERAPI_CLIENT_SECRET']})
     elif args.refresh:
         headers.update({'grant_type': 'refresh_token', 'refresh_token': args.refresh})

--- a/teslatoken.py
+++ b/teslatoken.py
@@ -25,8 +25,7 @@ def main():
     parser.add_argument("-r", "--refresh", metavar='REFRESH_TOKEN', default=None, help="Refresh token for an access token")
     parser.add_argument("-q", "--quiet", action='store_true', help="Do not print token to stdout")
     parser.add_argument('--version', action='version', version='%(prog)s 0.1')
-    parser.add_argument('--revoke', action='store_true', help="Revokes a previously acquired access token")
-    parser.add_argument('-a', '--access_token', metavar='ACCESS_TOKEN', help="The access token to be revoked")
+    parser.add_argument('--revoke', metavar='REVOKE_TOKEN', default=None, help="Revokes a previously acquired access token")
 
     args = parser.parse_args()
 
@@ -44,22 +43,22 @@ def main():
 
     request_url = 'https://owner-api.teslamotors.com/oauth/token';
     acquire_token = True
-    if args.username and args.password:
-        headers.update({'grant_type': 'password', 'email': args.username, 'password': args.password})
-        headers.update({'client_secret': client_data['OWNERAPI_CLIENT_SECRET']})
-    elif args.username and args.credential_file:
-        with open(args.credential_file) as f:
-            credentials = f.readline().strip()
+    if args.username and (args.password or args.credential_file):
+        if args.password:
+            credentials = args.password
+        else:
+            with open(args.credential_file) as f:
+                credentials = f.readline().strip()
         headers.update({'grant_type': 'password', 'email': args.username, 'password': credentials})
         headers.update({'client_secret': client_data['OWNERAPI_CLIENT_SECRET']})
     elif args.refresh:
         headers.update({'grant_type': 'refresh_token', 'refresh_token': args.refresh})
-    elif args.revoke and args.access_token:
+    elif args.revoke:
         request_url = 'https://owner-api.teslamotors.com/oauth/revoke';
         acquire_token = False
-        headers.update({'token': args.access_token})
+        headers.update({'token': args.revoke})
     else:
-        error('Either username/password or refresh token must be provided.')
+        error('Either username/password or refresh/revoke token must be provided.')
 
     try:
         request = Request(request_url, data=urlencode(headers).encode('utf-8'))


### PR DESCRIPTION
Add support for specifying a credential file which holds your password.

This is more secure than specifying the password on the command line
which can be intercepted by malicious shells as well as simply being
stored in your .history file.